### PR TITLE
Update Paint Worklet links

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,11 @@ Here's a quick list to all the demos. More details in the <a href="https://githu
   </ul>
   <li><strong>Paint Worklet</strong></li>
   <ul>
-    <li><a href="paint-worklet/circle">Circle in Textarea</a></li>
-    <li><a href="paint-worklet/ripple">Ripple</a></li>
-    <li><a href="paint-worklet/border-color">Border Color</a></li>
-    <li><a href="paint-worklet/checkerboard">Checkerboard</a></li>
-    <li><a href="paint-worklet/parameter-checkerboard">Parameterized Checkerboard</a></li>
-    <li><a href="paint-worklet/diamond-shape">Diamond-shaped DOM elements</a></li>
+    <li><a href="paint-worklet/circle/">Circle in Textarea</a></li>
+    <li><a href="paint-worklet/ripple/">Ripple</a></li>
+    <li><a href="paint-worklet/border-color/">Border Color</a></li>
+    <li><a href="paint-worklet/checkerboard/">Checkerboard</a></li>
+    <li><a href="paint-worklet/parameter-checkerboard/">Parameterized Checkerboard</a></li>
+    <li><a href="paint-worklet/diamond-shape/">Diamond-shaped DOM elements</a></li>
   </ul>
 </ul>


### PR DESCRIPTION
When I follow paint worklet links from the [list of samples](https://googlechromelabs.github.io/houdini-samples/) I'm taken to a non-https url, so the demo doesn't work.

It looks like GitHub's 301 response is switching protocols:

```
curl -I https://googlechromelabs.github.io/houdini-samples/paint-worklet/circle

HTTP/2 301
date: Sun, 21 Jan 2018 20:31:28 GMT
server: GitHub.com
content-type: text/html
location: http://googlechromelabs.github.io/houdini-samples/paint-worklet/circle/
...
```

Adding a trailing slash prevents the redirect.