### PR TITLE
Update polyfill to play nice with native implementation + cleanups

### DIFF
--- a/animation-worklet/anim-worklet.js
+++ b/animation-worklet/anim-worklet.js
@@ -448,26 +448,27 @@ limitations under the License.
       }
     }
 
+    function redefineGetter(obj, prop, value) {
+      Object.defineProperty(Object, prop, {
+        configurable: true,
+        get: function() { return value; }
+      });
+    }
+
     function exportSymbols(window) {
       function _export(){
+        window.registerAnimator = registerAnimator;
+
         window.WorkletAnimationKeyframeEffect = KeyframeEffect;
         window.WorkletAnimation = WorkletAnimation;
         window.ScrollTimeline = ScrollTimeline;
         window.DocumentTimeline = DocumentTimeline;
-        window.registerAnimator = registerAnimator;
-        window.CSS.animationWorklet = new AnimationWorklet();
-
         // Replace default keyframe effect with animation worklet version, and
         // document timeline with our version.
         window.KeyframeEffect = window.WorkletAnimationKeyframeEffect;
+        redefineGetter(window.document, 'timeline', new DocumentTimeline())
 
-        var docTimeline = new DocumentTimeline();
-        try {
-          Object.defineProperty(window.document, 'timeline', {
-            configurable: true,
-            get: function() { return docTimeline; }
-          });
-        } catch (e) { console.warn(e);}
+        redefineGetter(window.CSS, 'animationWorklet', new AnimationWorklet())
       }
 
       // Ensure the WebAnimations polyfill is loaded.

--- a/animation-worklet/anim-worklet.js
+++ b/animation-worklet/anim-worklet.js
@@ -406,6 +406,18 @@ limitations under the License.
         return [this.effect];
       }
 
+      getCurrentTime_(timelineTime) {
+        // Don't offset scroll timeline's current time.
+        if (this.timeline instanceof ScrollTimeline) {
+          return this.timeline.currentTime;
+        }
+
+        if (typeof this.startTime_ == "undefined")
+          this.startTime_ = this.timeline.currentTime;
+
+        return this.timeline.currentTime - this.startTime_;
+      }
+
       setNeedsUpdate_() {
         if (this.playState != 'running' ||
             this.needsUpdate_) return;
@@ -414,7 +426,7 @@ limitations under the License.
       }
 
       updateAnimation_() {
-        this.instance_.animate(this.timeline.currentTime, this.effect);
+        this.instance_.animate(this.getCurrentTime_(), this.effect);
         this.needsUpdate_ = false;
         // If this animation has any document timelines it will need an update
         // next frame.

--- a/animation-worklet/anim-worklet.js
+++ b/animation-worklet/anim-worklet.js
@@ -194,7 +194,7 @@ limitations under the License.
     }
 
     function scrollOffsetConst(offset, scrollSource) {
-       return offset;
+      return offset;
     }
 
     function scrollOffsetPercent(percent, scrollSource) {

--- a/animation-worklet/expando/index.html
+++ b/animation-worklet/expando/index.html
@@ -72,9 +72,11 @@ limitations under the License.
     </div>
   </div>
 </body>
+
+<script src="../anim-worklet.js"></script>
 <script>
-  window.addEventListener('load', function() {
-    window.animationWorklet.addModule('expando-animator.js').then(function(){
+  (window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
+    CSS.animationWorklet.addModule('expando-animator.js').then(function(){
       var expando = document.querySelector('.expando');
       var offset = document.querySelector('.expando .offset');
       var content = document.querySelector('.expando .content');

--- a/animation-worklet/expando/index.html
+++ b/animation-worklet/expando/index.html
@@ -23,8 +23,6 @@ limitations under the License.
   .expando {
     overflow: hidden;
     position: relative;
-    --animator-root: expand clip;
-    --expand-scale: 13;
   }
 
   .expando {
@@ -33,12 +31,7 @@ limitations under the License.
     width: 100px;
   }
 
-  .expando .content {
-    --animator: expand content;
-  }
-
   .expando .small {
-    --animator: expand small;
     border-radius: 5px;
     width: 360px;
     height: 500px;
@@ -47,7 +40,6 @@ limitations under the License.
   }
 
   .expando .large {
-    --animator: expand large;
     background: yellow;
     border-radius: 5px;
     width: 360px;
@@ -75,7 +67,7 @@ limitations under the License.
 
 <script src="../anim-worklet.js"></script>
 <script>
-  (window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
+  window.animationWorkletPolyfill.load().then(_=> {
     CSS.animationWorklet.addModule('expando-animator.js').then(function(){
       var expando = document.querySelector('.expando');
       var offset = document.querySelector('.expando .offset');

--- a/animation-worklet/parallax-scrolling/index.html
+++ b/animation-worklet/parallax-scrolling/index.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<html land="end">
+<html land="en">
 
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/animation-worklet/parallax-scrolling/index.html
+++ b/animation-worklet/parallax-scrolling/index.html
@@ -14,6 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<html land="end">
+
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>

--- a/animation-worklet/parallax-scrolling/index.html
+++ b/animation-worklet/parallax-scrolling/index.html
@@ -38,9 +38,8 @@ limitations under the License.
       height: 100vh;
       overflow: scroll;
       color: white;
-      background-color: rgba(0, 0, 0, 0.8);
+      background-color: rgba(0, 0, 0, 0.3);
       scroll-behavior: smooth;
-      --animator-root: parallax scroller;
     }
     .parallax {
       background-image: url('pic.jpg');
@@ -53,7 +52,6 @@ limitations under the License.
       top: 0;
       left: 0;
       z-index: -1;
-      --animator: parallax background;
     }
     #options {
       position: fixed;
@@ -123,3 +121,4 @@ limitations under the License.
 <script src="../anim-worklet.js"></script>
 <script src="parallax.js"></script>
 <script src="options.js"></script>
+</html>

--- a/animation-worklet/parallax-scrolling/parallax-animator.js
+++ b/animation-worklet/parallax-scrolling/parallax-animator.js
@@ -15,6 +15,8 @@ limitations under the License.
 */
 registerAnimator('parallax', class ParallaxAnimator {
   animate(currentTime, effect) {
-    effect.localTime = 200 * currentTime;
+    if (currentTime == NaN)
+      return;
+    effect.localTime = 0.2 * currentTime;
   }
 });

--- a/animation-worklet/parallax-scrolling/parallax.js
+++ b/animation-worklet/parallax-scrolling/parallax.js
@@ -55,14 +55,16 @@ document.addEventListener('DOMContentLoaded', function() {
       rafScheduled = true;
     };
   } else {
-    console.log('Using animation worklet rAF');
+    console.log('Using animation worklet');
+    (window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
 
-    window.animationWorklet.addModule('parallax-animator.js').then(function(){
-      var scrollRange = scroller.scrollHeight - scroller.clientHeight;
-      window.parallaxAnimator = new WorkletAnimation('parallax',
-          new KeyframeEffect(parallax, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + -scrollRange + 'px)'}], scrollRange),
-          new ScrollTimeline({scrollSource: scroller, orientation: 'vertical'}));
-      window.parallaxAnimator.play();
+      CSS.animationWorklet.addModule('parallax-animator.js').then(function(){
+        var scrollRange = scroller.scrollHeight - scroller.clientHeight;
+        window.parallaxAnimator = new WorkletAnimation('parallax',
+            new KeyframeEffect(parallax, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + -scrollRange + 'px)'}], scrollRange),
+            new ScrollTimeline({scrollSource: scroller, orientation: 'vertical'}));
+        window.parallaxAnimator.play();
+      });
     });
   }
 });

--- a/animation-worklet/parallax-scrolling/parallax.js
+++ b/animation-worklet/parallax-scrolling/parallax.js
@@ -56,7 +56,7 @@ document.addEventListener('DOMContentLoaded', function() {
     };
   } else {
     console.log('Using animation worklet');
-    (window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
+    window.animationWorkletPolyfill.load().then(_=> {
       CSS.animationWorklet.addModule('parallax-animator.js').then(function(){
         var scrollRange = scroller.scrollHeight - scroller.clientHeight;
         window.parallaxAnimator = new WorkletAnimation('parallax',

--- a/animation-worklet/parallax-scrolling/parallax.js
+++ b/animation-worklet/parallax-scrolling/parallax.js
@@ -57,12 +57,11 @@ document.addEventListener('DOMContentLoaded', function() {
   } else {
     console.log('Using animation worklet');
     (window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
-
       CSS.animationWorklet.addModule('parallax-animator.js').then(function(){
         var scrollRange = scroller.scrollHeight - scroller.clientHeight;
         window.parallaxAnimator = new WorkletAnimation('parallax',
             new KeyframeEffect(parallax, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + -scrollRange + 'px)'}], scrollRange),
-            new ScrollTimeline({scrollSource: scroller, orientation: 'vertical'}));
+            new ScrollTimeline({scrollSource: scroller, orientation: 'block', timeRange: scrollRange}));
         window.parallaxAnimator.play();
       });
     });

--- a/animation-worklet/spring-sticky/index.html
+++ b/animation-worklet/spring-sticky/index.html
@@ -112,9 +112,7 @@ limitations under the License.
 <script>
 // This demo uses multiple effects so we need to depend on polyfill. Force
 // polyfill to export its symbols.
-window.animationWorkletPolyfillPromise = window.animationWorkletPolyfillPromise || window.animationWorkletPolyfill.exportSymbols(window, CSS);
-
-window.animationWorkletPolyfillPromise.then(_=> {
+window.animationWorkletPolyfill.load(true /* forced */).then(_=> {
   CSS.animationWorklet.addModule('spring-sticky-animator.js').then(_=> {
     var scroller = document.getElementById('scroller');
     // Hack to be able to convert ScrollTimeline back into scroll position.

--- a/animation-worklet/spring-sticky/index.html
+++ b/animation-worklet/spring-sticky/index.html
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<html lang="en">
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
@@ -109,19 +110,25 @@ limitations under the License.
 </div>
 <script src="../anim-worklet.js"></script>
 <script>
-window.animationWorklet.addModule('spring-sticky-animator.js');
-document.addEventListener('DOMContentLoaded', function() {
-  var scroller = document.getElementById('scroller');
-  // Hack to be able to convert ScrollTimeline back into scroll position.
-  var scrollRange = (scroller.scrollHeight - scroller.clientHeight);
-  var effects = [];
-  var boxes = document.querySelectorAll('.sticky');
-  for (var i = 0; i < boxes.length; i++) {
-    effects.push(new KeyframeEffect(boxes[i], [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + scrollRange + 'px)'}], scrollRange));
-  }
-  window.stickyAnimation = new WorkletAnimation('spring-sticky', effects,
-    new ScrollTimeline({scrollSource: scroller, timeRange: scrollRange}),
-    {'documentTimeline': new DocumentTimeline()});
-  window.stickyAnimation.play();
+// This demo uses multiple effects so we need to depend on polyfill. Force
+// polyfill to export its symbols.
+window.animationWorkletPolyfillPromise = window.animationWorkletPolyfillPromise || window.animationWorkletPolyfill.exportSymbols(window, CSS);
+
+window.animationWorkletPolyfillPromise.then(_=> {
+  CSS.animationWorklet.addModule('spring-sticky-animator.js').then(_=> {
+    var scroller = document.getElementById('scroller');
+    // Hack to be able to convert ScrollTimeline back into scroll position.
+    var scrollRange = (scroller.scrollHeight - scroller.clientHeight);
+    var effects = [];
+    var boxes = document.querySelectorAll('.sticky');
+    for (var i = 0; i < boxes.length; i++) {
+      effects.push(new KeyframeEffect(boxes[i], [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + scrollRange + 'px)'}], scrollRange));
+    }
+    window.stickyAnimation = new WorkletAnimation('spring-sticky', effects,
+      new ScrollTimeline({scrollSource: scroller, timeRange: scrollRange}),
+      {'documentTimeline': new DocumentTimeline()});
+    window.stickyAnimation.play();
+  });
 });
 </script>
+</html>

--- a/animation-worklet/spring-timing/index.html
+++ b/animation-worklet/spring-timing/index.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<html>
+<html lang="en">
 
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/animation-worklet/spring-timing/index.html
+++ b/animation-worklet/spring-timing/index.html
@@ -27,8 +27,7 @@ limitations under the License.
 </body>
 <script src="../anim-worklet.js"></script>
 <script>
-(window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
-
+window.animationWorkletPolyfill.load().then(_=> {
   const BUCKET_SIZE = 10;
 
   const springCountEl = document.getElementById('springCount');

--- a/animation-worklet/spring-timing/index.html
+++ b/animation-worklet/spring-timing/index.html
@@ -25,15 +25,17 @@ limitations under the License.
   <ul>
   </ul>
 </body>
-<!-- <script src="../anim-worklet.js"></script> -->
+<script src="../anim-worklet.js"></script>
 <script>
+(window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
+
   const BUCKET_SIZE = 10;
 
   const springCountEl = document.getElementById('springCount');
   const springContainerEl = document.querySelector('ul');
   window.springAnimations = [];
 
-  window.animationWorklet.addModule('spring-timing-animator.js').then(function() {
+  CSS.animationWorklet.addModule('spring-timing-animator.js').then(function() {
     springCountEl.addEventListener('input', createAnimations);
     createAnimations();
   });
@@ -80,6 +82,7 @@ limitations under the License.
     containerEl.appendChild(li);
     return target;
   }
+});
 </script>
 
 </html>

--- a/animation-worklet/twitter-header/index.html
+++ b/animation-worklet/twitter-header/index.html
@@ -72,9 +72,14 @@ limitations under the License.
   if (location.protocol === 'http:' && location.hostname !== 'localhost') {
     location.protocol = 'https:';
   }
-  if (!('animationWorklet' in self)) {
+  var animationWorklet = window.animationWorklet;
+  if (CSS)
+    animationWorklet = CSS.animationWorklet;
+
+  if (!animationWorklet) {
     document.body.innerHTML = 'You need support for <a href="https://wicg.github.io/animation-worklet/">Animation Worklet</a> to view this demo :(';
   }
+
   [
     '--avatar-size',
     '--avatar-border',

--- a/animation-worklet/twitter-hidey-bar/index.html
+++ b/animation-worklet/twitter-hidey-bar/index.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<html>
+<html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="style.css">
@@ -55,8 +55,13 @@ limitations under the License.
       </section>
       <script src="../anim-worklet.js"></script>
       <script>
-        document.addEventListener('DOMContentLoaded', function() {
-          window.animationWorklet.addModule('twitter-header-animator.js').then(function(){
+        // This demo uses multiple timelines which is not implemented natively
+        // so we need to depend on polyfill. Force polyfill to export its
+        // symbols.
+        window.animationWorkletPolyfillPromise = window.animationWorkletPolyfillPromise || window.animationWorkletPolyfill.exportSymbols(window);
+
+        (window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
+          CSS.animationWorklet.addModule('twitter-header-animator.js').then(function(){
             var scroller = document.getElementById('scroller');
             var avatar = document.querySelector('.avatar');
             var avatarPicture = avatar.querySelector('img');
@@ -64,7 +69,7 @@ limitations under the License.
             var barSection = bar.querySelector('section');
             var scrollRange = (scroller.scrollHeight - scroller.clientHeight);
             var primaryTimeline = new ScrollTimeline({scrollSource: scroller, orientation: 'vertical', phase: true});
-            window.twitterAnimation = new WorkletAnimation('twitter-header', [
+            twitterAnimation = new WorkletAnimation('twitter-header', [
                 new KeyframeEffect(avatarPicture, [{'transform': 'translate(0, 0) scale(1)'}, {'transform': 'translate(-27px, 0) scale(0.4)'}], {duration: 144, fill: 'both'}),
                 new KeyframeEffect(avatar, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + scrollRange + 'px)'}], scrollRange),
                 new KeyframeEffect(bar, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + scrollRange + 'px)'}], scrollRange),
@@ -76,7 +81,7 @@ limitations under the License.
                     endScrollOffset: '144px', timeRange: 144}),
                 scrollRange: scrollRange,
               });
-            window.twitterAnimation.play();
+            twitterAnimation.play();
           });
         });
       </script>

--- a/animation-worklet/twitter-hidey-bar/index.html
+++ b/animation-worklet/twitter-hidey-bar/index.html
@@ -58,9 +58,7 @@ limitations under the License.
         // This demo uses multiple timelines which is not implemented natively
         // so we need to depend on polyfill. Force polyfill to export its
         // symbols.
-        window.animationWorkletPolyfillPromise = window.animationWorkletPolyfillPromise || window.animationWorkletPolyfill.exportSymbols(window);
-
-        (window.animationWorkletPolyfillPromise || Promise.resolve()).then(_=> {
+        window.animationWorkletPolyfill.load(true /* forced */).then(_=> {
           CSS.animationWorklet.addModule('twitter-header-animator.js').then(function(){
             var scroller = document.getElementById('scroller');
             var avatar = document.querySelector('.avatar');


### PR DESCRIPTION
Update polyfill to play nice with native implementation + cleanups

This patch updates polyfill export logic to work better with native implementation.

For testing, I have checked that all demos work with latest Chromium Canary with
and w/o Experimental Web Platform Features flag.

## Polyfill Changes

- Polyfill now populates CSS namespace
- Reworked symbol export logic:
    1. Introduce a single place to export so we don't partially export stuff
    2. Make it clear that exporting symbols is actually an async as it depends on 
        loading web-animation polyfill
    3. polyfill can now be forced to load overwriting native implementation.
- currentTime is now offset per animation matching spec and native implementation.

## Demo Changes

- Update parallax demo to work on native AW implementaiton. 
  Defined ScrollTimeline orientation and timeRange.
- Re-enable polyfill for spring-timing demo since polyfill now gets along with
  native implementaiton.
- Use load(true) to force polyfill for demos that need unimplemented features.

## Smaller Cleanups

- remove legacy `--animator-root` etc.
- remove unused `get()` function.
- add <html land="en"> to avoid chrome translation prompt.
- Smaller readability related cleanups

