### PR TITLE
Fix AnimationWorklet expando jitter issue

### DIFF
--- a/animation-worklet/expando/expando-animator.js
+++ b/animation-worklet/expando/expando-animator.js
@@ -10,8 +10,7 @@ registerAnimator('expando', class ExpandAnimator {
       t = Math.max(0, 4 - repeatTime);
     else
       t = 1;
-
-    effect.localTime = t;
+    effect.localTime = t * 1000;
   }
 });
 
@@ -36,6 +35,6 @@ registerAnimator('reverseExpando', class ReverseExpandAnimator {
     // Counter-scale the content elements.
     var counterScale = 1 / scale;
     var maxCounterScale = 1 / expandScale;
-    effect.localTime = (counterScale - 1) / (maxCounterScale - 1);
+    effect.localTime = (counterScale - 1) / (maxCounterScale - 1) * 1000;
   }
 });

--- a/animation-worklet/expando/index.html
+++ b/animation-worklet/expando/index.html
@@ -75,7 +75,7 @@ limitations under the License.
       var smallContent = document.querySelector('.expando .small');
       var largeContent = document.querySelector('.expando .large');
       var expandScale = 13;
-      var effectOptions = {duration: 1, fill: 'both'};
+      var effectOptions = {duration: 1000, fill: 'both'};
 
       const expando_effect = new KeyframeEffect(expando, [{'transform': 'scale(1)'}, {'transform': 'scale(' + expandScale + ')'}], effectOptions);
       const content_effect = new KeyframeEffect(content, [{'transform': 'scale(1)'}, {'transform': 'scale(' + (1 / expandScale) + ')'}], effectOptions);


### PR DESCRIPTION
The original implementation uses duration 1ms. Given that Chrome animation time is precise only up to 1 microsecond this means that the calculation are going to lose precision which causes the jitter.
Increasing the duration to 1000ms and updating computations accordingly gets rid of the jitter.

See the recordings here for the effect of the fix: https://bugs.chromium.org/p/chromium/issues/detail?id=887949#c1
