### PR TITLE
Update demos to behave correctly if using stateful animator

### DIFF
--- a/animation-worklet/spring-timing/spring-timing-animator.js
+++ b/animation-worklet/spring-timing/spring-timing-animator.js
@@ -24,16 +24,12 @@ registerAnimator('spring', class SpringAnimator {
       };
     }
 
-    this.options_ = options
-    console.log('Initializing spring animation with ', this.options_);
+    this.options_ = options;
+    // initialize the simulation.
+    this.springTiming_ =  this.spring(this.options_.k, this.options_.ratio);
   }
 
   animate(currentTime, effect) {
-    if (!this.springTiming_)  {
-      // initialize the simulation.
-      this.springTiming_ =  this.spring(this.options_.k, this.options_.ratio);
-    }
-
     // TODO(majidvp): stop computing a new value once we are within a certain
     // threshold of the target.
     const dt_seconds = currentTime / 1000;

--- a/animation-worklet/trip-app/index.html
+++ b/animation-worklet/trip-app/index.html
@@ -121,9 +121,6 @@
           <img src="http://source.unsplash.com/DE4T0fOApF0">
         </figure>
         <figure class="figure">
-          <img src="http://source.unsplash.com/AJgFLjnmSs4">
-        </figure>
-        <figure class="figure">
           <img src="http://source.unsplash.com/JMYBetGDIKY">
         </figure>
         <figure class="figure">

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@ Here's a quick list to all the demos. More details in the <a href="https://githu
     <li><a href="animation-worklet/spring-timing/">Spring Timing</a></li>
     <li><a href="animation-worklet/spring-sticky/">Sticky Spring</a></li>
     <li><a href="animation-worklet/expando/">Expando effect</a></li>
+    <li><a href="animation-worklet/trip-app/">Swipe-to-Action and Scroll-to-Section</a></li>
   </ul>
   <li><strong>Paint Worklet</strong></li>
   <ul>


### PR DESCRIPTION
Update the demos to behave correctly in case they are stateful.

Here are the summary changes:

Trip-app:
 - Add appropriate state function so this behave correctly now that Chrome does scope switching.
 - Use this.options, this.state
 - Formatting clean ups
 - Remove additinal figure
 - Add to list of demos

Spring timing:
 - Move spring initialization to ctor and remove extra logging