### PR TITLE
Fix optional "disabled" attribute

### DIFF
--- a/layout-worklet/relative/main.js
+++ b/layout-worklet/relative/main.js
@@ -69,7 +69,7 @@ function updateRelativeStyle(constraints) {
 }
 
 const selectTmpl = (items, selected, disabled) => html`
-  <select disabled="${disabled}">
+  <select ?disabled="${disabled}">
     ${items.map(
       item =>
         html`${


### PR DESCRIPTION
Layout example "relative" has all its `select` elements disabled, though its value is
`disabled="false"`, because browsers will consider it disabled anyway.

This fixes this bug by making `disabled` atrribute optional.
